### PR TITLE
Replace opensuse repos with shibboleth.org work around

### DIFF
--- a/configs/centos-6/Dockerfile
+++ b/configs/centos-6/Dockerfile
@@ -2,8 +2,9 @@ FROM centos:6
 MAINTAINER "JCU eResearch Centre" <eresearch.nospam@jcu.edu.au>
 
 # Install from OpenSUSE's Shibboleth repository
-RUN curl https://download.opensuse.org/repositories/security://shibboleth/CentOS_CentOS-6/security:shibboleth.repo > /etc/yum.repos.d/shibboleth.repo
-RUN rpm --import https://download.opensuse.org/repositories/security:/shibboleth/CentOS_CentOS-6/repodata/repomd.xml.key
+#RUN curl https://download.opensuse.org/repositories/security://shibboleth/CentOS_CentOS-6/security:shibboleth.repo > /etc/yum.repos.d/shibboleth.repo
+#RUN rpm --import https://download.opensuse.org/repositories/security:/shibboleth/CentOS_CentOS-6/repodata/repomd.xml.key
+ADD configs/centos-6/shibboleth.repo /etc/yum.repos.d/shibboleth.repo
 
 # Configure EPEL for fcgi-devel
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm

--- a/configs/centos-6/shibboleth.repo
+++ b/configs/centos-6/shibboleth.repo
@@ -1,0 +1,8 @@
+[shibboleth]
+name=Shibboleth (CentOS_CentOS-6)
+# Please report any problems to https://issues.shibboleth.net
+type=rpm-md
+mirrorlist=https://shibboleth.net/cgi-bin/mirrorlist.cgi/CentOS_CentOS-6
+gpgcheck=1
+gpgkey=https://downloadcontent.opensuse.org/repositories/security:/shibboleth/CentOS_CentOS-6/repodata/repomd.xml.key
+enabled=1

--- a/configs/centos-7/Dockerfile
+++ b/configs/centos-7/Dockerfile
@@ -2,8 +2,9 @@ FROM centos:7
 MAINTAINER "JCU eResearch Centre" <eresearch.nospam@jcu.edu.au>
 
 # Install from OpenSUSE's Shibboleth repository
-RUN curl https://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/security:shibboleth.repo > /etc/yum.repos.d/shibboleth.repo
-RUN rpm --import https://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/repodata/repomd.xml.key
+#RUN curl https://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/security:shibboleth.repo > /etc/yum.repos.d/shibboleth.repo
+#RUN rpm --import https://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/repodata/repomd.xml.key
+ADD configs/centos-7/shibboleth.repo /etc/yum.repos.d/shibboleth.repo
 
 # Install EPEL for fcgi-devel
 RUN yum install -y epel-release

--- a/configs/centos-7/shibboleth.repo
+++ b/configs/centos-7/shibboleth.repo
@@ -1,0 +1,8 @@
+[shibboleth]
+name=Shibboleth (CentOS_7)
+# Please report any problems to https://issues.shibboleth.net
+type=rpm-md
+mirrorlist=https://shibboleth.net/cgi-bin/mirrorlist.cgi/CentOS_7
+gpgcheck=1
+gpgkey=https://downloadcontent.opensuse.org/repositories/security:/shibboleth/CentOS_7/repodata/repomd.xml.key
+enabled=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,14 @@
 version: '2'
 services:
   shibboleth-fastcgi-build-centos-6:
-    build: configs/centos-6/
+    build: 
+      context: .
+      dockerfile: ./configs/centos-6/Dockerfile
     volumes:
       - .:/app
   shibboleth-fastcgi-build-centos-7:
-    build: configs/centos-7/
+    build:
+      context: .
+      dockerfile: ./configs/centos-7/Dockerfile
     volumes:
       - .:/app


### PR DESCRIPTION
Using this to create an internal shibboleth yum repo for my nginx servers that's updated nightly. The opensuse repo's are breaking too often and creating issues using either the build script directly or the docker containers. Based on https://shibboleth.net/downloads/service-provider/latest/RPMS/ I created a static yum repo file to use with the docker containers. This is just a temporary fix until they can resolve the repo issues. Because of this you may not want to merge this but I figure I'll leave it up to you.